### PR TITLE
[PROCESSO SELETIVO] Deixa algumas instruções menos confusas

### DIFF
--- a/processo_seletivo_front_end/atividade_4.md
+++ b/processo_seletivo_front_end/atividade_4.md
@@ -4,7 +4,7 @@ O intuito dessa atividade é consolidar a prática do desenvolvimento usando HTM
 
 Então nessa semana eu vou apenas passar um template para vocês transformá-lo em uma página com os conhecimentos adquiridos nas últimas 3 atividades.
 
-Os arquivos de referência para fazer o site estão no link abaixo:
+Os arquivos de referência para fazer o site estão no link abaixo (utilizem o email institucional da Unesp para obter o acesso direto):
 https://drive.google.com/drive/folders/14nAxFYEYf8OZCftYCuZSDBhw7qVhrW1Z?usp=sharing
 
 ### Template da página

--- a/processo_seletivo_front_end/atividade_7.md
+++ b/processo_seletivo_front_end/atividade_7.md
@@ -6,11 +6,14 @@ A atividade será efetuar a manipulação do DOM necessária para adicionar duas
 
 Para utilizar a máscara de input, utilizaremos a biblioteca Vanilla Masker, que é muito simples de usar.
 Link da documentação do Vanilla Masker: https://vanilla-masker.github.io/vanilla-masker/
-Basta importar a biblioteca, no HTML e adicionar o seguinte código ao JavaScript do site para adicionar uma máscara ao input do telefone:
+
+Baixando e salvando o arquivo .js da `development version`, basta importá-lo no HTML como script e adicionar o seguinte código ao JavaScript do site para adicionar uma máscara ao input do telefone:
 
 ```javascript
 VMasker(document.querySelector('#phone')).maskPattern('(99) 9999-9999');
 ```
+
+O mesmo deve ser feito com o código postal, só mudando o argumento do maskPattern.
 
 Quanto ao navbar, o procedimento será substituir onde está escrito _"Increase your muscle size & strength"_ no canto superior direito da tela, por uma lista de links que, usando flex box, será estilizada para permanecer na horizontal e com o mesmo estilo de texto do site.
 
@@ -38,3 +41,5 @@ document.querySelectorAll('a[href^="#"]').forEach(function (element) {
   })(document.querySelector(element.hash));
 });
 ```
+
+OBS: Se o scroll ainda não estiver macio, isto é, ainda for diretamente para a seção sem animação alguma, isto provavelmente é sinal de que seu navegador está configurado para não utilizá-lo ou então não o suporta. No primeiro caso, basta verificar e alterar as configurações e flags relacionadas a `smooth scrool` do navegador que você utiliza, ou então utilizar outro, no segundo caso.

--- a/processo_seletivo_front_end/atividade_7.md
+++ b/processo_seletivo_front_end/atividade_7.md
@@ -42,4 +42,4 @@ document.querySelectorAll('a[href^="#"]').forEach(function (element) {
 });
 ```
 
-OBS: Se o scroll ainda não estiver macio, isto é, ainda for diretamente para a seção sem animação alguma, isto provavelmente é sinal de que seu navegador está configurado para não utilizá-lo ou então não o suporta. No primeiro caso, basta verificar e alterar as configurações e flags relacionadas a _smooth scrool_ do navegador que você utiliza, ou então utilizar outro, no segundo caso.
+OBS: Se o scroll ainda não estiver macio, isto é, ainda for diretamente para a seção sem animação alguma, isto provavelmente é sinal de que seu navegador está configurado para não utilizá-lo ou então não o suporta. No primeiro caso, basta verificar e alterar as configurações e flags relacionadas a _smooth scroll_ do navegador que você utiliza, ou então utilizar outro, no segundo caso.

--- a/processo_seletivo_front_end/atividade_7.md
+++ b/processo_seletivo_front_end/atividade_7.md
@@ -7,7 +7,7 @@ A atividade será efetuar a manipulação do DOM necessária para adicionar duas
 Para utilizar a máscara de input, utilizaremos a biblioteca Vanilla Masker, que é muito simples de usar.
 Link da documentação do Vanilla Masker: https://vanilla-masker.github.io/vanilla-masker/
 
-Baixando e salvando o arquivo .js da `development version`, basta importá-lo no HTML como script e adicionar o seguinte código ao JavaScript do site para adicionar uma máscara ao input do telefone:
+Baixando e salvando o arquivo .js da _development version_, basta importá-lo no HTML como script e adicionar o seguinte código ao JavaScript do site para adicionar uma máscara ao input do telefone:
 
 ```javascript
 VMasker(document.querySelector('#phone')).maskPattern('(99) 9999-9999');
@@ -42,4 +42,4 @@ document.querySelectorAll('a[href^="#"]').forEach(function (element) {
 });
 ```
 
-OBS: Se o scroll ainda não estiver macio, isto é, ainda for diretamente para a seção sem animação alguma, isto provavelmente é sinal de que seu navegador está configurado para não utilizá-lo ou então não o suporta. No primeiro caso, basta verificar e alterar as configurações e flags relacionadas a `smooth scrool` do navegador que você utiliza, ou então utilizar outro, no segundo caso.
+OBS: Se o scroll ainda não estiver macio, isto é, ainda for diretamente para a seção sem animação alguma, isto provavelmente é sinal de que seu navegador está configurado para não utilizá-lo ou então não o suporta. No primeiro caso, basta verificar e alterar as configurações e flags relacionadas a _smooth scrool_ do navegador que você utiliza, ou então utilizar outro, no segundo caso.


### PR DESCRIPTION
Fiz recentemente o processo seletivo front-end e, em algumas partes, gastei alguns minutos bestas tentando adivinhar as causas quando algo não ocorria como esperado, mas a solução era simples ou então não era aonde eu pensava que seria.

Esta PR faz pequenas alterações em pequenos Markdowns de duas atividades do curso.

Algumas observações ainda, mas que fogem ao meu alcance:

- O curso da atividade 3 está desatualizado, a inclusão do FontAwesome é diferente e o curso em si é focado para pessoas que já tem certa experiência com comandos mais específicos do CSS, tanto é que o ritmo é bem acelerado e o criador passa direto sobre certas coisas. Além disso, os arquivos necessários para fazer o site do Hotel, exemplo utilizado no curso, não estão mais disponíveis (o site do autor não está mais no ar, e o canal também foi abandonado, aparentemente).
- Talvez fosse importante introduzir a implementação de Regex no JavaScript na atividade 6, função de teste, etc. Mas não alterei pois imaginei que ocultar isto tinha o intuito de forçar o aprendiz a pesquisar por conta própria as coisas.